### PR TITLE
[hotfix] - UserPointServiceTests stub에 System.currentTimeMillis()로 값 세팅하여 테스트 실패하는 경우 발생하여 전역변수에 세팅 후 사용하도록 수정

### DIFF
--- a/src/test/java/io/hhplus/tdd/unit/UserPointServiceTests.java
+++ b/src/test/java/io/hhplus/tdd/unit/UserPointServiceTests.java
@@ -37,6 +37,8 @@ class UserPointServiceTests {
 
 	//유저 ID
 	private final long id = 11L;
+	//현재시간
+	private final long currentTimeMillis = System.currentTimeMillis();
 
 	@Test
 	@DisplayName("[포인트 충전][최대 잔고 초과]충전 요청 포인트 + 소유 포인트가 1,000,000P 초과 일때 충전 실패")
@@ -46,7 +48,7 @@ class UserPointServiceTests {
 		long chargePointAmount = 2L;
 
 		//최대 잔고에 근접한 유저포인트 Mock 객체
-		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,999_999L,System.currentTimeMillis()));
+		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,999_999L,currentTimeMillis));
 	//When
 		UserPointService userPointService = new UserPointService(userPointTable,pointHistoryTable);
 		CustomException ce = assertThrows(CustomException.class,() -> userPointService.chargePoint(id, chargePointAmount),"충천 포인트 0P");
@@ -64,9 +66,9 @@ class UserPointServiceTests {
 		long chargePointAmount = 1_000L;
 
 		//소유 포인트가 없는 유저포인트 Mock 객체
-		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,0L,System.currentTimeMillis()));
+		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,0L,currentTimeMillis));
 		//chargePointAmount 만큼 포인트 충전된 Mock 객체
-		when(userPointTable.insertOrUpdate(id,chargePointAmount)).thenReturn(new UserPoint(id,chargePointAmount,System.currentTimeMillis()));
+		when(userPointTable.insertOrUpdate(id,chargePointAmount)).thenReturn(new UserPoint(id,chargePointAmount,currentTimeMillis));
 	//When
 		UserPointService userPointService = new UserPointService(userPointTable,pointHistoryTable);
 		UserPoint afterChargeUserPoint =  userPointService.chargePoint(id, chargePointAmount);
@@ -84,15 +86,15 @@ class UserPointServiceTests {
 		long chargePointAmount = 1_000L;
 
 		//소유 포인트가 없는 유저포인트 Mock 객체
-		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,0L,System.currentTimeMillis()));
+		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,0L,currentTimeMillis));
 		//chargePointAmount 만큼 포인트 충전된 Mock 객체
-		when(userPointTable.insertOrUpdate(id,chargePointAmount)).thenReturn(new UserPoint(id,chargePointAmount,System.currentTimeMillis()));
+		when(userPointTable.insertOrUpdate(id,chargePointAmount)).thenReturn(new UserPoint(id,chargePointAmount,currentTimeMillis));
 
-		PointHistory chargePointHistory = new PointHistory(1,id,chargePointAmount,TransactionType.CHARGE,System.currentTimeMillis());
+		PointHistory chargePointHistory = new PointHistory(1,id,chargePointAmount,TransactionType.CHARGE,currentTimeMillis);
 		List<PointHistory> pointHistories = new ArrayList<>();
 		pointHistories.add(chargePointHistory);
 		//충전 내역 입력 Mock 객체
-		when(pointHistoryTable.insert(id,chargePointAmount,TransactionType.CHARGE,System.currentTimeMillis())).thenReturn(chargePointHistory);
+		when(pointHistoryTable.insert(id,chargePointAmount,TransactionType.CHARGE,currentTimeMillis)).thenReturn(chargePointHistory);
 		//충전 내역 조회 Mock 객체
 		when(pointHistoryTable.selectAllByUserId(id)).thenReturn(pointHistories);
 	//When
@@ -116,7 +118,7 @@ class UserPointServiceTests {
 		long usePointAmount = 100_000L;
 
 		//소유 포인트를 ValueSouce에서 입력받는 유저포인트 Mock 객체
-		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,ownPointAmount,System.currentTimeMillis()));
+		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,ownPointAmount,currentTimeMillis));
 	//When
 		UserPointService userPointService = new UserPointService(userPointTable,pointHistoryTable);
 		CustomException ce = assertThrows(CustomException.class,() -> userPointService.usePoint(id, usePointAmount - ownPointAmount),"잔여 포인트 부족");
@@ -135,9 +137,9 @@ class UserPointServiceTests {
 		long remainingUserPointAmount = ownUserPointAmount - usePointAmount;
 
 		//소유 포인트 10_000P 유저포인트 Mock 객체
-		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,ownUserPointAmount,System.currentTimeMillis()));
+		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,ownUserPointAmount,currentTimeMillis));
 		//usePointAmount 만큼 포인트 사용 후 remainingUserPointAmount 유저포인트 Mock 객체
-		when(userPointTable.insertOrUpdate(id,remainingUserPointAmount)).thenReturn(new UserPoint(id,remainingUserPointAmount,System.currentTimeMillis()));
+		when(userPointTable.insertOrUpdate(id,remainingUserPointAmount)).thenReturn(new UserPoint(id,remainingUserPointAmount,currentTimeMillis));
 	//When
 		UserPointService userPointService = new UserPointService(userPointTable,pointHistoryTable);
 		UserPoint afterUseUserPoint =  userPointService.usePoint(id, usePointAmount);
@@ -156,15 +158,15 @@ class UserPointServiceTests {
 		long remainingUserPointAmount = ownUserPointAmount - usePointAmount;
 
 		//소유 포인트 10_000P 유저포인트 Mock 객체
-		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,ownUserPointAmount,System.currentTimeMillis()));
+		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,ownUserPointAmount,currentTimeMillis));
 		//usePointAmount 만큼 포인트 사용 후 remainingUserPointAmount 유저포인트 Mock 객체
-		when(userPointTable.insertOrUpdate(id,remainingUserPointAmount)).thenReturn(new UserPoint(id,remainingUserPointAmount,System.currentTimeMillis()));
+		when(userPointTable.insertOrUpdate(id,remainingUserPointAmount)).thenReturn(new UserPoint(id,remainingUserPointAmount,currentTimeMillis));
 
-		PointHistory usePointHistory = new PointHistory(1,id,usePointAmount,TransactionType.USE,System.currentTimeMillis());
+		PointHistory usePointHistory = new PointHistory(1,id,usePointAmount,TransactionType.USE,currentTimeMillis);
 		List<PointHistory> pointHistories = new ArrayList<>();
 		pointHistories.add(usePointHistory);
 		//사용 내역 입력 Mock 객체
-		when(pointHistoryTable.insert(id,usePointAmount,TransactionType.USE,System.currentTimeMillis())).thenReturn(usePointHistory);
+		when(pointHistoryTable.insert(id,usePointAmount,TransactionType.USE,currentTimeMillis)).thenReturn(usePointHistory);
 		//사용 내역 조회 Mock 객체
 		when(pointHistoryTable.selectAllByUserId(id)).thenReturn(pointHistories);
 	//When
@@ -187,7 +189,7 @@ class UserPointServiceTests {
 		long ownUserPointAmount = 10_000L;
 
 		//소유 포인트 10_000P 유저포인트 Mock 객체
-		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,ownUserPointAmount,System.currentTimeMillis()));
+		when(userPointTable.selectById(id)).thenReturn(new UserPoint(id,ownUserPointAmount,currentTimeMillis));
 	//When
 		UserPointService userPointService = new UserPointService(userPointTable,pointHistoryTable);
 		UserPoint currentUserPoint = userPointService.selectUserPoint(id);
@@ -202,8 +204,8 @@ class UserPointServiceTests {
 		long chargePointAmount = 10_000L;
 		long usePointAmount = 1_000L;
 
-		PointHistory chargePointHistory = new PointHistory(1,id,chargePointAmount,TransactionType.CHARGE,System.currentTimeMillis());
-		PointHistory usePointHistory = new PointHistory(2,id,usePointAmount,TransactionType.USE,System.currentTimeMillis());
+		PointHistory chargePointHistory = new PointHistory(1,id,chargePointAmount,TransactionType.CHARGE,currentTimeMillis);
+		PointHistory usePointHistory = new PointHistory(2,id,usePointAmount,TransactionType.USE,currentTimeMillis);
 		List<PointHistory> pointHistories = new ArrayList<>();
 		pointHistories.add(chargePointHistory);
 		pointHistories.add(usePointHistory);


### PR DESCRIPTION

### **커밋 링크**
<!-- 
좋은 피드백을 받기 위해 가장 중요한 것은 코드를 작성할 때 커밋을 작업 단위로 잘 쪼개는 것입니다.
모든 작업을 하나의 커밋에 진행하고 PR을 하면 구조 파악에 많은 시간을 소모하기 때문에 절대로
좋은 피드백을 받을 수 없습니다.


필수 양식)
커밋 이름 : 커밋 링크

예시)
동시성 처리 : c83845
동시성 테스트 코드 : d93ji3
-->

---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1
- 리뷰 포인트 2
<!-- - 리뷰어가 특히 확인해야 할 부분이나 신경 써야 할 코드가 있다면 명확히 작성해주세요.(최대 2개)
  
  좋은 예:
  - `ErrorMessage` 컴포넌트의 상태 업데이트 로직이 적절한지 검토 부탁드립니다.
  - 추가한 유닛 테스트(`LoginError.test.js`)의 테스트 케이스가 충분한지 확인 부탁드립니다.

  나쁜 예:
  - 개선사항을 알려주세요.
  - 코드 전반적으로 봐주세요.
  - 뭘 질문할지 모르겠어요. -->
---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->

### Problem
<!--개선이 필요한 점-->

### Try
<!-- 새롭게 시도할 점 -->
